### PR TITLE
Fix broken relative link on asyncapi page

### DIFF
--- a/content/documentation/using/asyncapi.md
+++ b/content/documentation/using/asyncapi.md
@@ -85,7 +85,7 @@ examples:
         age: 36
 ```
 
-> You can see here that we're using specific `{{ }}` notation that involves the generation of dynamic content. You can find description of the `now()` and `randomString()` functions into [Function Expressions](./advanced/templates/#function-expressions) documentation.
+> You can see here that we're using specific `{{ }}` notation that involves the generation of dynamic content. You can find description of the `now()` and `randomString()` functions into [Function Expressions](../advanced/templates/#function-expressions) documentation.
 
 #### Headers
 


### PR DESCRIPTION
Sorry for the out of the blue PR, but I noticed a broken link when 
following the docs for AsyncAPI - hope this is okay!

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>