### PR TITLE
Proofing some of the 'using' section

### DIFF
--- a/content/documentation/using/advanced.md
+++ b/content/documentation/using/advanced.md
@@ -15,9 +15,9 @@ weight: 30 #rem
 
 ## Content negocation in REST mocks
 
-Microcks mocks engine supports [Content Negociation](https://restfulapi.net/content-negotiation/) for REST APIs based on `Accept` HTTP header.
+Microcks mocks engine supports [Content Negotiation](https://restfulapi.net/content-negotiation/) for REST APIs based on `Accept` HTTP header.
 
-So supposed you have defined 2 representations for the same example of a `GET /pastry/{name}` operation into your API contract:
+So suppose you have defined 2 representations for the same example of a `GET /pastry/{name}` operation into your API contract:
 
 * One describing a JSON response like below
 
@@ -27,7 +27,7 @@ So supposed you have defined 2 representations for the same example of a `GET /p
 
 ![content-negociation-xml](/images/content-negociation-xml.png)
 
-Both samples are matching the same dispatch criterion that is the `name` part of the URI. However depending on the `Accept` header of your request, Microcks will return different responses:
+Both samples match the same dispatch criterion that is the `name` part of the URI. However, Microcks will return different responses depending on the `Accept` header of your request:
 
 ```sh
 $ curl http://localhost:8080/rest/API+Pastry+-+2.0/2.0.0/pastry/Eclair+Cafe
@@ -53,9 +53,9 @@ Sometimes it may be important to specify additional constraints onto a Mock oper
 
 Constraints can be put onto `Query` or `Header` parameters and are of 3 types:
 
-* `required` constraints are forcing the presence of parameter in incoming request,
-* `recopy` constraints are just sending back the same parameter name and value into mock response,
-* `match` constraints are checking the value of a parameter against a specified regular expression.
+* `required` constraints force the presence of parameter in incoming request,
+* `recopy` constraints just send back the same parameter name and value into mock response,
+* `match` constraints check the value of a parameter against a specified regular expression.
 
 Now imagine you put such constraints onto the `GET /pastry` operation of your REST API that is secured using a JWT Bearer and should managed tracabelity using a correlation id:
 
@@ -125,7 +125,7 @@ x-request-id: 123
 ]
 ```
 
-> Operation parameters constraints are saved into Microcks database and not replaced by a new importation of your Service or API definition. They can be independently set and updated using the [Microcks APIs](../automating/api/).
+> Operation parameter constraints are saved into Microcks database and not replaced by a new import of your Service or API definition. They can be independently set and updated using the [Microcks APIs](../automating/api/).
 
 ## Override default headers during tests
 

--- a/content/documentation/using/mocks.md
+++ b/content/documentation/using/mocks.md
@@ -15,15 +15,15 @@ weight: 30 #rem
 
 ## Using exposed mocks
     
-### Getting infos on microservices mocks
+### Getting info on microservices mocks
 			
-Well, now that you have [installed](/documentation/getting-staretd) Microcks, created your own API/Service repository using [OpenAPI](../openapi/), [AsyncAPI](../asyncapi/), [SoapUI](../soapui/) or [Postman](../postman/) and discover how to [import and browse content](/documentation/getting-started), you are ready to learn more about how to use mocks managed by Microcks.
+Well, now that you have [installed](/documentation/getting-started) Microcks, created your own API/Service repository using [OpenAPI](../openapi/), [AsyncAPI](../asyncapi/), [SoapUI](../soapui/) or [Postman](../postman/) and discovered how to [import and browse content](/documentation/getting-started), you are ready to learn more about how to use mocks managed by Microcks.
 
-First, let's have a look at the summary page presenting an API or Service managed by Microcks. This summary page contains three sections related to different part of the API/Service :
+First, let's have a look at the summary page presenting an API or Service managed by Microcks. This summary page contains three sections related to different parts of the API/Service :
 
-* `Properties` section show basic information on API/Service : its name, its version, its style (REST or SOAP) and you'll also got access to statistics regarding the utilization of the mocks of this API. SOAP style Service also contains extra information like the global `XML Namespace` used by the Service and the embedded `WSDL contract` if any was provided,
-* `Tests trend` section shows a little histogram representing the latest tests trend on this API/Service. It provides an access to test history and for launching a new test on an API/Service implementation. More on this topic in the [](./tests/">Tests documentation</a>,
-* `Operations` section concentrates informations on the different operations managed by this API or Service. More on that topic below.
+* `Properties` section shows basic information on the API/Service : its name, its version, its style (REST or SOAP) and you'll also get access to statistics such as the utilization of this API's mocks. SOAP style Services also contain extra information like the global `XML Namespace` used by the Service and the embedded `WSDL contract` if any was provided,
+* `Tests trend` section shows a little histogram representing the latest tests trend on this API/Service. It provides access to the test history and allows a new test on an API/Service implementation to be launched. More on this topic in the [Tests](/documentation/using/tests) documentation</a>,
+* `Operations` section concentrates on the different operations managed by this API or Service. More on that topic below.
 
 			
 ![mock-rest-summary](/images/mock-rest-summary.png)
@@ -32,22 +32,22 @@ Here's an example of summary page for a SOAP Service mock :
 			
 ![mock-soap-summary](/images/mock-soap-summary.png)
 			
-Let's now focus on the `Operations` section of this page. A click on the operation name, unveil its details. Within an Operation panel, you will get generic information on this operation as well as visualization of typical request/response pairs examples (payload content and headers). 2 major informations should be isolated here are :
+Let's now focus on the `Operations` section of this page. A click on the operation name unveils its details. Within an Operation panel, you will get generic information on this operation as well as visualization of typical request/response pair examples (payload content and headers). Two major highlights should be pointed out here :
 
-* The `Mocks URL`: this is the URL fragment to which are exposed the mocks for this Operation of the API/Service. This fragment should be appended to your Microcks server URL to form a invokable URL. For example: `http://microcks-microcks.192.168.99.100.nip.io/rest/Test+API/0.0.1/order/:id`. When this URL contains variables part, this part is instanciated within each example panel,
-* The `Dispatcher` and `Dispatching Rules` used by this operation. These elements are used by Microcks for finding an appropriate response to return receiving a mock request. It tells the user of the mocks what should be the immutable elements of his requests wether they may be located into the URL, the query string or the body payload. Microcks supports many dispatcher implementations whose names are rather self-explanatory. You may find: `URI_PARTS`, `URI_PARAMS`, `URI_ELEMENTS`, `QUERY_MATCH` or `SCRIPT`
+* The `Mocks URL`: this is the URL fragment to which are exposed the mocks for this Operation of the API/Service. This fragment should be appended to your Microcks server URL to form an invokable URL. For example: `http://microcks-microcks.192.168.99.100.nip.io/rest/Test+API/0.0.1/order/:id`. When this URL contains variables part, this part is instantiated within each example panel,
+* The `Dispatcher` and `Dispatching Rules` used by this operation. These elements are used by Microcks for finding an appropriate response to return when receiving a mock request. It tells the user of the mocks what should be the immutable elements of their request whether they may be located in the URL, the query string or the body payload. Microcks supports many dispatcher implementations whose names are rather self-explanatory. You may find: `URI_PARTS`, `URI_PARAMS`, `URI_ELEMENTS`, `QUERY_MATCH` or `SCRIPT`
 			
 ![mock-details](/images/mock-details.png)
 			
-In the REST API mock example above, you can guess that the `:id` part of the Mock URL is used as the only criterion for finding accurate response when invoking mock. In the SOAP API mock example below, we use a much more elaborated dispatcher that is called `QUERY_MATCH` and uses the companion XPath expression provided as `Dispatching Rules` to extract from request payload the criterion for finding matching response.
+In the REST API mock example above, you will guess that the `:id` part of the Mock URL is used as the only criterion for finding a specific response when invoking the mock. In the SOAP API mock example below, we use a much more elaborate dispatcher called `QUERY_MATCH` and use the companion XPath expression provided as `Dispatching Rules` to extract from the request payload the criterion for finding the matching response.
 			
 ![mock-soap-details](/images/mock-soap-details.png)
 		
 ### Invoking microservices mocks
 			
-Invoking Mocks is now pretty easy if you have read the upper section! Just use Microcks for searching the API/Service you want to use and explore the operations of the API/Service. Find the Mock URL and the Http method of the corresponding operation, look at the instanciated URI fragment for different request/response pairs, append the fragment to the Microcks server url and that's it!
+Invoking Mocks is now pretty easy if you have read the section above! Just use Microcks for searching the API/Service you want to use and explore the operations of the API/Service. Find the Mock URL and the Http method of the corresponding operation, look at the instanciated URI fragment for different request/response pairs, append the fragment to the Microcks server url and that's it!
 
-As a rule of thumb, here is how the URL fragment for mocks are built and exposed within Microcks :
+As a rule of thumb, here is how the URL fragments for mocks are built and exposed within Microcks :
 
 * Mocks for REST API mocks are exposed on `/rest` sub-context. Mock for SOAP API mocks are exposed on `/soap` sub-context,
 * Name of API/Service is then added as path element of URL. Special characters of name are encoded within URL part,
@@ -68,7 +68,7 @@ Easy !?
 
 | Param | Type | Description | Default / Examples |
 | ----- | ---- | ----------- | ------------------ |
-| **validate** | boolean | In case of a SOAP microservice with defined WSDL/XSD contract, the mock may realize a validation of XML payload send by consumer if this parameter is set to true. | Default is **false** |
-| **delay** | positive integer | Set a response delay to simulate slow responding systems and check behavior of the service consumer being under tests. Note: this is an execution simulation response time: validation time and network latency are not taken into account | Default is **0**. Use for example 1000, to have a 1 second delay on mock invocation |
+| **validate** | boolean | In case of a SOAP microservice with a defined WSDL/XSD contract, the mock will perform a validation of the XML payload sent by consumer if this parameter is set to true. | Default is **false** |
+| **delay** | positive integer | Set a response delay to simulate slow responding systems and to check the behavior of the service consumer under test. Note: this is an execution simulation response time: validation time and network latency are not taken into account | Default is **0**. Use for example 1000, to have a 1 second delay on mock invocation |
 
-This parameters may be used in addition of the Mock URL displayed on microservice informations page and should be append to the query URL. You may end up with URLs such as : `http://microcks.example.com/soap/HelloService/1.0/sayHello/?delay=250&validate=true`
+These parameters may be used in addition of the Mock URL displayed on the microservice's information page and should be append to the query URL. You will end up with URLs such as : `http://microcks.example.com/soap/HelloService/1.0/sayHello/?delay=250&validate=true`

--- a/content/documentation/using/mocks.md
+++ b/content/documentation/using/mocks.md
@@ -34,7 +34,7 @@ Here's an example of summary page for a SOAP Service mock :
 			
 Let's now focus on the `Operations` section of this page. A click on the operation name unveils its details. Within an Operation panel, you will get generic information on this operation as well as visualization of typical request/response pair examples (payload content and headers). Two major highlights should be pointed out here :
 
-* The `Mocks URL`: this is the URL fragment to which are exposed the mocks for this Operation of the API/Service. This fragment should be appended to your Microcks server URL to form an invokable URL. For example: `http://microcks-microcks.192.168.99.100.nip.io/rest/Test+API/0.0.1/order/:id`. When this URL contains variables part, this part is instantiated within each example panel,
+* The `Mocks URL`: this is the URL that exposes the mocks for this Operation of the API/Service. For example: `http://microcks-microcks.192.168.99.100.nip.io/rest/Test+API/0.0.1/order/:id`. When this URL contains variables part, this part is instantiated within each example panel,
 * The `Dispatcher` and `Dispatching Rules` used by this operation. These elements are used by Microcks for finding an appropriate response to return when receiving a mock request. It tells the user of the mocks what should be the immutable elements of their request whether they may be located in the URL, the query string or the body payload. Microcks supports many dispatcher implementations whose names are rather self-explanatory. You may find: `URI_PARTS`, `URI_PARAMS`, `URI_ELEMENTS`, `QUERY_MATCH` or `SCRIPT`
 			
 ![mock-details](/images/mock-details.png)
@@ -45,7 +45,7 @@ In the REST API mock example above, you will guess that the `:id` part of the Mo
 		
 ### Invoking microservices mocks
 			
-Invoking Mocks is now pretty easy if you have read the section above! Just use Microcks for searching the API/Service you want to use and explore the operations of the API/Service. Find the Mock URL and the Http method of the corresponding operation, look at the instanciated URI fragment for different request/response pairs, append the fragment to the Microcks server url and that's it!
+Invoking Mocks is now pretty easy if you have read the section above! Just use Microcks for searching the API/Service you want to use and then explore the operations of the API/Service. Find the Mock URL and the Http method of the corresponding operation, look at the instantiated URI for each example request/response pair, copy the URI to your favorite http client and you're ready to go!
 
 As a rule of thumb, here is how the URL fragments for mocks are built and exposed within Microcks :
 


### PR DESCRIPTION
Proofing of mocks.md and advanced.md.  Minor corrections to language use in both plus, in mocks.md, replacing references to the user having to build the mock url from the server url and mock uri fragments - this was necessary in earlier versions of Microcks, but not now.