### PR TITLE
adding directive for changing redirectUris

### DIFF
--- a/content/documentation/installing/deployment-options.md
+++ b/content/documentation/installing/deployment-options.md
@@ -84,6 +84,8 @@ First, you have to prepare your Keycloak instance to host and secure future Micr
 * **Create a new realm** using [Keycloak documentation](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-a-realm_server_administration_guide) and choosing [Microcks realm full configuration](https://github.com/microcks/microcks/raw/master/install/keycloak-microcks-realm-full.json) as the file to import during creation,
 * OR **Re-use an existing realm**, completing its definition with [Microcks realm addons configuration](https://github.com/microcks/microcks/blob/master/install/keycloak-microcks-realm-addons.json) by simply importing this file within realm configuration.
 
+> You might want to change the `redirectUris` in the Microcks realm configuration file to the corresponding URI of the Microcks application, by default it is pointing to localhost.
+
 Importing one or another of the Microcks realm configuration file will bring all the necessary clients, roles, groups and scope mappings. If you created a new realm, the Microcks configuration also brings default users you may later delete when configuring your [own identity provider in Keycloak](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker).
 
 Then, you actually have to deploy the Microcks instance configured for using external Keycloak. Depending whether you've used Helm or Operator to install Microcks, you'll have to customize your `values.yml` file or the `MicrocksInstall` custom resource but the properties have the same names in both installation methods:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
In [Reusing Existing Keycloak](https://microcks.io/documentation/installing/deployment-options/#reusing-existing-keycloak) section, there are 2 realm JSON files being listed as an example. In both JSON files, the redirectUris is pointing to localhost:8080.

https://github.com/microcks/microcks/blob/master/install/keycloak-microcks-realm-addons.json#L80
https://github.com/microcks/microcks/blob/master/install/keycloak-microcks-realm-full.json#L128

In the case where we are deploying this to non-local environment, this will not work. We should add a suggestion to update the realm file accordingly.

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->