### PR TITLE
Update links to organizing the Microcks repository in documentation

### DIFF
--- a/content/blog/microcks-0.9.0-release.md
+++ b/content/blog/microcks-0.9.0-release.md
@@ -68,7 +68,7 @@ As a repository content manager, we add new features regarding repository organi
 
 Labels can also be used on the main repository page allowing you to filter and display the most important labels when browsing repository content.
 
-> Full details are documented here: https://microcks.io/documentation/using/advanced/organizing/
+> Full details are documented here: https://microcks.io/documentation/using/organizing/
 
 ## Mocking enhancements
 

--- a/content/blog/microcks-1.4.1-release.md
+++ b/content/blog/microcks-1.4.1-release.md
@@ -31,7 +31,7 @@ For each and every tenant, Microcks takes care of creating and managing dedicate
 {{< image src="images/blog/users-group-management.png" alt="image" zoomable="true" >}}
 
 
-> How to enable and manage a multi-tenant repository? It’s very easy! New options have been added into both Helm Chart and Operator. Check our updated documentation on [activation](https://microcks.io/documentation/using/advanced/organizing/#rbac-security-segmentation) and user [groups management](https://microcks.io/documentation/administrating/users/#group-membership).
+> How to enable and manage a multi-tenant repository? It’s very easy! New options have been added into both Helm Chart and Operator. Check our updated documentation on [activation](https://microcks.io/documentation/using/organizing/#rbac-security-segmentation) and user [groups management](https://microcks.io/documentation/administrating/users/#group-membership).
 
 
 ### Scaling labels using new APIMetadata

--- a/content/blog/microcks-1.6.0-release.md
+++ b/content/blog/microcks-1.6.0-release.md
@@ -33,7 +33,7 @@ But how to easily figure this out at first sight? That’s why we introduced the
 
 {{< image src="images/blog/test-conformance.png" alt="image" zoomable="true" >}}
 
-By just checking these visual indicators, you immediately grasp if your tests are comprehensive for conformance validation and what is the current score and trend. What if you start having dozens of APIs or Services in your Microcks repository? The Microcks dashboard has evolved to display aggregated information on that too. Depending on the [master level filter](https://microcks.io/documentation/using/advanced/organizing/#master-level-filter) you’ve chosen to organize your repository, aggregated Conformance score will be computed and displayed in a tree map. Here is below an example where scores are grouped by `domain`:
+By just checking these visual indicators, you immediately grasp if your tests are comprehensive for conformance validation and what is the current score and trend. What if you start having dozens of APIs or Services in your Microcks repository? The Microcks dashboard has evolved to display aggregated information on that too. Depending on the [master level filter](https://microcks.io/documentation/using/organizing/#master-level-filter) you’ve chosen to organize your repository, aggregated Conformance score will be computed and displayed in a tree map. Here is below an example where scores are grouped by `domain`:
 
 {{< image src="images/blog/test-conformance-risks.png" alt="image" zoomable="true" >}}
 

--- a/content/documentation/administrating/users.md
+++ b/content/documentation/administrating/users.md
@@ -84,7 +84,7 @@ Users can only be managed by Microcks `admin` - we mean people having the `admin
 
 ### Group membership
 
-From Microcks 1.4.0, you have the ability to segment the role attribution depending on the `master` label you have chosen for organizing your repository. See [Organizing repository](https://microcks.io/documentation/using/advanced/organizing/#rbac-security-segmentation) for details on this feature.
+From Microcks 1.4.0, you have the ability to segment the role attribution depending on the `master` label you have chosen for organizing your repository. See [Organizing repository](https://microcks.io/documentation/using/organizing/#rbac-security-segmentation) for details on this feature.
 
 When this feature is enabled, Microcks will create as many groups in Keycloak as we have different values for this `master` label. These groups are organized in a hierarchy so that you'll have groups with such names `/microcks/manager/<label>` those members represents the `manager` of the resources labeled with `<label>` value.
 

--- a/content/documentation/using/asyncapi.md
+++ b/content/documentation/using/asyncapi.md
@@ -206,7 +206,7 @@ Using the above `User signed-up API` example, you should get the following resul
 
 Microcks proposes custom AsyncAPI extensions to specify mocks organizational or behavioral elements that cannot be deduced directly from AsyncAPI document.
 
-At the `info` level of your AsyncAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../advanced/organizing). See below illustration and the use of `x-microcks` extension:
+At the `info` level of your AsyncAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../organizing). See below illustration and the use of `x-microcks` extension:
 
 ```yaml
 asyncapi: '2.1.0'

--- a/content/documentation/using/asyncapi.md
+++ b/content/documentation/using/asyncapi.md
@@ -206,7 +206,7 @@ Using the above `User signed-up API` example, you should get the following resul
 
 Microcks proposes custom AsyncAPI extensions to specify mocks organizational or behavioral elements that cannot be deduced directly from AsyncAPI document.
 
-At the `info` level of your AsyncAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../organizing). See below illustration and the use of `x-microcks` extension:
+At the `info` level of your AsyncAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](https://microcks.io/documentation/using/organizing/). See below illustration and the use of `x-microcks` extension:
 
 ```yaml
 asyncapi: '2.1.0'

--- a/content/documentation/using/metadata.md
+++ b/content/documentation/using/metadata.md
@@ -46,7 +46,7 @@ operations:
 This example is pretty straightforward to understand and explain:
 
 * This document is related to the `WeatherForecast API` in version `1.1.0`. That means that this API version should already exist into your repository, otherwise the document will be ignored,
-* This document specifies additional `labels` used for [organizing the Microcks repository](../advanced/organizing). This labels will be added to existing ones,
+* This document specifies additional `labels` used for [organizing the Microcks repository](../organizing). This labels will be added to existing ones,
 * This document specifies a default `delay` as well as custom dispatching informations for our `GET` operation. The name of operation should perfectly match the name of an existing operation - whether defined through OpenAPI, AsyncAPI, Postman Collection, SoapUI Project or Protobuf definition - otherwise it will be ignored.
 
 > Note that we can use multi-line notation in YAML but we will have to escape everything and put `\` before double-quotes and `\n` characters if specified using JSON.

--- a/content/documentation/using/metadata.md
+++ b/content/documentation/using/metadata.md
@@ -46,7 +46,7 @@ operations:
 This example is pretty straightforward to understand and explain:
 
 * This document is related to the `WeatherForecast API` in version `1.1.0`. That means that this API version should already exist into your repository, otherwise the document will be ignored,
-* This document specifies additional `labels` used for [organizing the Microcks repository](../organizing). This labels will be added to existing ones,
+* This document specifies additional `labels` used for [organizing the Microcks repository](https://microcks.io/documentation/using/organizing/). This labels will be added to existing ones,
 * This document specifies a default `delay` as well as custom dispatching informations for our `GET` operation. The name of operation should perfectly match the name of an existing operation - whether defined through OpenAPI, AsyncAPI, Postman Collection, SoapUI Project or Protobuf definition - otherwise it will be ignored.
 
 > Note that we can use multi-line notation in YAML but we will have to escape everything and put `\` before double-quotes and `\n` characters if specified using JSON.

--- a/content/documentation/using/openapi.md
+++ b/content/documentation/using/openapi.md
@@ -176,7 +176,7 @@ Using the above `Car API` example, you should get the following results:
 
 Starting with version `1.4.0`, Microcks proposes custom OpenAPI extensions to specify mocks organizational or behavioral elements that cannot be deduced directly from OpenAPI document.
 
-At the `info` level of your OpenAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../organizing). See below illustration and the use of `x-microcks` extension:
+At the `info` level of your OpenAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](https://microcks.io/documentation/using/organizing/). See below illustration and the use of `x-microcks` extension:
 
 ```yaml
 openapi: 3.1.0

--- a/content/documentation/using/openapi.md
+++ b/content/documentation/using/openapi.md
@@ -176,7 +176,7 @@ Using the above `Car API` example, you should get the following results:
 
 Starting with version `1.4.0`, Microcks proposes custom OpenAPI extensions to specify mocks organizational or behavioral elements that cannot be deduced directly from OpenAPI document.
 
-At the `info` level of your OpenAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../advanced/organizing). See below illustration and the use of `x-microcks` extension:
+At the `info` level of your OpenAPI document, you can add labels specifications that will be used in [organizing the Microcks repository](../organizing). See below illustration and the use of `x-microcks` extension:
 
 ```yaml
 openapi: 3.1.0

--- a/content/documentation/using/tests.md
+++ b/content/documentation/using/tests.md
@@ -35,7 +35,7 @@ The **Conformance index** is a kind of grade that estimates how your API contrac
 
 The **Conformance score** is the current score that has been computed during your last test execution. We also added a trend computation if things are going better or worse comparing to your history of tests on this API.
 
-Once you have activated [labels filtering](./advanced/organizing/#applying-labels) on your repository and have ran a few tests, Microcks is also able to give you an aggregated view of your API patrimony in termes of **Conformance Risks**. The tree map below is displayed on the *Dashboard* page and represents risks in terms of average score per group of APIs (depending on the concept you chose it could be per domain, per application, per team, ...)
+Once you have activated [labels filtering](../organizing/#applying-labels) on your repository and have ran a few tests, Microcks is also able to give you an aggregated view of your API patrimony in termes of **Conformance Risks**. The tree map below is displayed on the *Dashboard* page and represents risks in terms of average score per group of APIs (depending on the concept you chose it could be per domain, per application, per team, ...)
 
 {{< image src="images/test-conformance-risks.png" alt="image" zoomable="true" >}}
 


### PR DESCRIPTION
Update links to "organizing repository" in documentation to latest ui

### Description

Updated pages:

1. Administrating
- users
2. Using
- asyncapi
- metadata
- openapi
- tests

### Related issue(s)

Fix #73 