### PR TITLE
type: netxork > network

### DIFF
--- a/content/documentation/tutorials/getting-started-tests.md
+++ b/content/documentation/tutorials/getting-started-tests.md
@@ -52,7 +52,7 @@ Now you have everything ready to launch your first test with Microcks!
 Now that our component implementing the API is running, it's time to launch some tests to check if it is actually compliant with the API Contract. This is what we call **Contract Testing**. You can launch and run tests from the UI or from the [`microcks-cli`](/documentation/guides/automation/cli/) tool.
 
 > 💡 
-> As our API implement is runing into a container bound on port 8282, it will be accessible at `http://localhost:8282` from our machine network. However, from the Microcks container perspective it will be accessible using the `http://host.docker.internal:8282` alias that allow accessing the machine netxork from inside a container.
+> As our API implement is runing into a container bound on port 8282, it will be accessible at `http://localhost:8282` from our machine network. However, from the Microcks container perspective it will be accessible using the `http://host.docker.internal:8282` alias that allow accessing the machine network from inside a container.
 
 
 ### From the UI


### PR DESCRIPTION
Just spotted a typo `netxork` and changed it to `network`.