### PR TITLE
Examples json-schema file is outdated

### DIFF
--- a/content/documentation/references/examples.md
+++ b/content/documentation/references/examples.md
@@ -15,7 +15,7 @@ weight: 6
 
 `APIExamples` files are simple YAML and aim to be very easy to understand and edit. More over, the description is independant from the API protocol! We're rather attached to describe examples depending on the API interaction style: Request/Response based or Event-driven/Asynchronous.
 
-For ease of use, we provide a [JSON Schema](https://json-schema.org/) that you can [download here](https://raw.githubusercontent.com/microcks/microcks/be2ceeb84263b71fbdc11bef69c1c9044f8284ba/api/APIExamples-v1alpha1-schema.json). Thus, you can integrate it in your code editor and benefit from code completion and validation.
+For ease of use, we provide a [JSON Schema](https://json-schema.org/) that you can [download here](https://raw.githubusercontent.com/microcks/microcks/refs/heads/master/api/APIExamples-v1alpha1-schema.json). Thus, you can integrate it in your code editor and benefit from code completion and validation.
 
 `APIExamples` documents are intended to be imported as `secondary` artifacts only ; thanks to the [Multi-Artifacts support](/documentation/explanations/multi-artifacts).
 

--- a/content/documentation/references/examples.md
+++ b/content/documentation/references/examples.md
@@ -15,7 +15,7 @@ weight: 6
 
 `APIExamples` files are simple YAML and aim to be very easy to understand and edit. More over, the description is independant from the API protocol! We're rather attached to describe examples depending on the API interaction style: Request/Response based or Event-driven/Asynchronous.
 
-For ease of use, we provide a [JSON Schema](https://json-schema.org/) that you can [download here](/schemas/APIExamples-v1alpha1-schema.json). Thus, you can integrate it in your code editor and benefit from code completion and validation.
+For ease of use, we provide a [JSON Schema](https://json-schema.org/) that you can [download here](https://raw.githubusercontent.com/microcks/microcks/be2ceeb84263b71fbdc11bef69c1c9044f8284ba/api/APIExamples-v1alpha1-schema.json). Thus, you can integrate it in your code editor and benefit from code completion and validation.
 
 `APIExamples` documents are intended to be imported as `secondary` artifacts only ; thanks to the [Multi-Artifacts support](/documentation/explanations/multi-artifacts).
 


### PR DESCRIPTION
The json-schema file is outdated compared to the schema supported by Microcks. I would suggest you link to the GitHub file to avoid the mismatch.

Example:
The actual schema requires `response.status`, but the provided file requires `response.code`.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- ...
- ...
- ...

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->