### PR TITLE
Correct artifact upload URL in curl example

### DIFF
--- a/content/documentation/guides/usage/importing-content.md
+++ b/content/documentation/guides/usage/importing-content.md
@@ -39,7 +39,7 @@ Once you have the `$TOKEN` issued for the correct account, uploading a new Artif
 
 ```sh
 # Uploading a local artifact.
-curl 'https://microcks.example.com/api/artifacts/upload?mainArtifact=true' -H "Authorization: Bearer $TOKEN" -F 'file=@samples/films.graphql' -k
+curl 'https://microcks.example.com/api/artifact/upload?mainArtifact=true' -H "Authorization: Bearer $TOKEN" -F 'file=@samples/films.graphql' -k
 ```
 
 ### Configure dependency resolution


### PR DESCRIPTION
I received a 404 from Microcks when trying the original URL.

Refer to the path in the Microcks API documentation: https://github.com/microcks/microcks/blob/7c4f413b3e025ba40d447fdd3fc20702511f2d82/api/microcks-openapi-v1.10.yaml#L248