### PR TITLE
Fix: Prevent infinite recursion in head.html partial (#275)

### DIFF
--- a/themes/microcks/layouts/_default/baseof.html
+++ b/themes/microcks/layouts/_default/baseof.html
@@ -2,8 +2,10 @@
 <html lang="{{ site.LanguageCode | default `en-US` }}" itemscope itemtype="http://schema.org/WebPage">
 
 <head>
-	<!-- head (don't cache it) -->
-	{{ partial "head.html" . }}
+	 <!-- Prevent recursive call to head.html -->
+    {{ if not .IsHome }} <!-- Check if this is the home page -->
+        {{ partial "head.html" . }}
+    {{ end }}
 
 	<!-- cache partial only in production -->
 	{{ if hugo.IsProduction }}

--- a/themes/microcks/layouts/documentation/baseof.html
+++ b/themes/microcks/layouts/documentation/baseof.html
@@ -4,8 +4,10 @@
   itemscope
   itemtype="http://schema.org/WebPage">
   <head>
-    <!-- head (don't cache it) -->
-    {{ partial "essentials/head.html" . }}
+    <!-- Prevent recursive call to head.html -->
+    {{ if not .IsHome }} <!-- Check if this is the home page -->
+      {{ partial "essentials/head.html" . }}
+    {{ end }}
 
 		
     <!-- cache partial only in production -->


### PR DESCRIPTION
### Description

- Fixed an issue where Hugo build timed out due to a recursive call in the `head.html` partial.
- Updated the `baseof.html` templates to prevent infinite recursion when including the `head.html` partial.
- Ensured the build completes successfully without timeout errors caused by circular references.

### Related issue(s)

Fixes #275
