### PR TITLE
Fix 295: Admin and password not highlighted 

### DIFF
--- a/content/documentation/guides/installation/podman-compose.md
+++ b/content/documentation/guides/installation/podman-compose.md
@@ -51,8 +51,8 @@ This will start the required containers and setup a simple environment for your 
 
 Open a new browser tab and point to the `http://localhost:8080` endpoint. This will redirect you to the [Keycloak](https://www.keycloak.org/) Single Sign On page for login. Use the following default credentials to login into the application:
 
-* **Username:** admin
-* **Password:** microcks123
+* **Username:** `admin`
+* **Password:** `microcks123`
 
 You will be redirected to the main dashboard page.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
Resolves #295 
Updated the podman-compose.md file to ensure admin and password are part of "code" and hence highlighted.

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->