### PR TITLE
Fix 315: GLightbox Plugin Imported

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -74,8 +74,8 @@ link = "plugins/font-awesome/v6/solid.css"
 link = "plugins/font-awesome/v6/regular.css"
 [[params.plugins.css]]
 link = "plugins/font-awesome/v6/icons.css"
-# [[params.plugins.css]]
-# link = "plugins/glightbox/glightbox.css"
+[[params.plugins.css]]
+link = "plugins/glightbox/glightbox.css"
 
 # JS Plugins
 [[params.plugins.js]]
@@ -88,8 +88,8 @@ link = "plugins/cookie.js"
 link = "plugins/lazy-loader.js"
 [[params.plugins.js]]
 link = "js/tab.js"
-# [[params.plugins.js]]
-# link = "plugins/glightbox/glightbox.js"
+[[params.plugins.js]]
+link = "plugins/glightbox/glightbox.js"
 # [[params.plugins.js]]
 # link = "js/gallery-slider.js"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
Resolves #315
Enabled the plugin import. 
This helps remove the unnecessary error shown on the website console.