### PR TITLE
Fix typo: 'ressources' → 'resources' on Community page

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -1,8 +1,8 @@
 ---
-title: "Microcks community and ressources"
+title: "Microcks community and resources"
 subtitle: ""
 # meta description
-description: "Microcks community and ressources"
+description: "Microcks community and resources"
 draft: false
 layout: "how-it-works"
 
@@ -44,5 +44,5 @@ how_it_works:
 
   - title: "Logos and assets"
     image: "images/community/logo.png"
-    content: "Here are a few [ressources](https://microcks.io/resources/) in case you want to **show off your support** for Microcks, **integrate** Microcks, or want to **link back** to us. Please feel **free to borrow** these!" 
+    content: "Here are a few [resources](https://microcks.io/resources/) in case you want to **show off your support** for Microcks, **integrate** Microcks, or want to **link back** to us. Please feel **free to borrow** these!" 
 ---


### PR DESCRIPTION
```md
## Description

This pull request fixes a typo on the Community page where "ressources" is used instead of "resources." The change updates the text in the corresponding markdown file to reflect the correct spelling.

## Related Issue

No related issue created for this typo fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes a minor typo)

## Checklist

- [x] My code follows the existing style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (if applicable)
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
```