### PR TITLE
docs: fix typos in docs-overview

### DIFF
--- a/content/documentation/overview/what-is-microcks.md
+++ b/content/documentation/overview/what-is-microcks.md
@@ -15,9 +15,9 @@ Microcks is a [Cloud Native Computing Foundation (CNCF) Sandbox project](https:/
 
 <br/>
 
-### Who can use Microcks for?
+### Who can use Microcks?
 
-Depending on your profile, you way use Microcks to gain different advantages:
+Depending on your profile, you may use Microcks to gain different advantages:
 
 <section class="mt-5">
   <div class="container">
@@ -30,7 +30,7 @@ Depending on your profile, you way use Microcks to gain different advantages:
         <ul>
           <li>Get instant feedback on design iterations with Microcks powered simulations</li>
           <li>Leverage <a href="/documentation/references/artifacts/">Open Standards</a> and ensure re-use for easy communication</li>
-          <li>Share simulations and conformance certification tests kit with your teams and partners</li>
+          <li>Share simulations and conformance certification test kits with your teams and partners</li>
           <li>Assess and monitor <a href="/documentation/explanations/conformance-testing/">conformance quality risks</a> of your API and services portfolio</li>
         </ul>
       </div>


### PR DESCRIPTION
### Description

- Fixed the typo in the section "Who can use Microcks?" by removing the unnecessary "for."
- Corrected the wording of "you way use Microcks" to "you may use Microcks."
- Updated the phrase "Share simulations and conformance certification tests kit" to "test kits."

### Related issue(s)
fixes #353

