### PR TITLE
fix: update broken links in Importing Services & APIs page

### DIFF
--- a/content/documentation/guides/usage/importing-content.md
+++ b/content/documentation/guides/usage/importing-content.md
@@ -33,7 +33,7 @@ While this method is very convenient for a quick test, you'll have to re-import 
 
 ### Via the API
 
-The same thing can be done via Microcks' own API. Be sure to start reading the [Connecting to Microcks API](/automation/api.md) guide first, and to retrieve a `token` by running the authentication flow. The *Service Account* you use for this operation is required to have the `manager` role - that is not the case of the default one as explained in [Inspecting default Service Account](/microcks.io/documentation/explanations/service-account/#inspecting-default-service-account).
+The same thing can be done via Microcks' own API. Be sure to start reading the [Connecting to Microcks API](/documentation/guides/automation/api) guide first, and to retrieve a `token` by running the authentication flow. The *Service Account* you use for this operation is required to have the `manager` role - that is not the case of the default one as explained in [Inspecting default Service Account](/documentation/explanations/service-account/#inspecting-default-service-account).
 
 Once you have the `$TOKEN` issued for the correct account, uploading a new Artifact is just a matter of executing this `curl` command:
 


### PR DESCRIPTION

### **Description**
- Fixed broken links in the **Importing Services & APIs** documentation page that resulted in 404 errors.
- Updated incorrect URLs pointing to non-existent pages.


#### **Broken Links and Fixes**
- **Actual (Broken Link):**  
  [https://microcks.io/automation/api.md](https://microcks.io/automation/api.md)  
  **Updated Link:**  
  [https://microcks.io/documentation/guides/automation/api/](https://microcks.io/documentation/guides/automation/api/)

- **Actual (Broken Link):**  
  [https://microcks.io/microcks.io/documentation/explanations/service-account/#inspecting-default-service-account](https://microcks.io/microcks.io/documentation/explanations/service-account/#inspecting-default-service-account)  
  **Updated Link:**  
  [https://microcks.io/documentation/explanations/service-account/#inspecting-default-service-account](https://microcks.io/documentation/explanations/service-account/#inspecting-default-service-account)

### **Related Issue(s)**
Resolves #376


This PR ensures that users navigating the documentation do not encounter broken links and can access the correct resources seamlessly. 🚀
