### PR TITLE
fix: update broken link to conformance metrics

### DIFF
--- a/content/documentation/references/test-endpoints.md
+++ b/content/documentation/references/test-endpoints.md
@@ -27,7 +27,8 @@ Depending on your API/Service type and the protocol binding you want to connect 
 
 ### Test Runner
 
-Microcks offers different strategies for running tests on endpoints where our microservice being developed are deployed. We recommend having a read at our explanations on [Conformance Testing](/documentation/explanations/conformance-metrics). Such strategies are implemented as **Test Runners**. Here are the default Test Runners available within Microcks:
+Microcks offers different strategies for running tests on endpoints where our microservice being developed are deployed. We recommend having a read at our explanations on [Conformance Testing](/documentation/explanations/conformance-testing/#conformance-metrics
+). Such strategies are implemented as **Test Runners**. Here are the default Test Runners available within Microcks:
 			
 | <div style="width: 160px">Test Runner</div> | <div style="width: 160px">API & Service Types</div> | Description |
 | ----------- | ----------------- | ----------- |


### PR DESCRIPTION
Fixes: #413 

### Description
Fixed broken link to "Conformance Metrics" section on the Test Endpoints reference page.

### Changes Made 
- Updated broken URL on line 30 of [test-endpoints.md](https://github.com/microcks/microcks.io/blob/master/content/documentation/references/test-endpoints.md)
- Changed from: https://microcks.io/documentation/explanations/conformance-metrics (404)
- Changed to: https://microcks.io/documentation/explanations/conformance-testing/#conformance-metrics

## Testing
- [x] Verified the new link works correctly
- [x] Link now properly navigates to the Conformance Metrics section
