### PR TITLE
Master

### DIFF
--- a/content/documentation/explanations/deployment-options.md
+++ b/content/documentation/explanations/deployment-options.md
@@ -67,7 +67,7 @@ var microcks = new MicrocksContainer(DockerImageName.parse("quay.io/microcks/mic
 microcks.start();
 ```
 
-Please check our [Developing with Testcontainers guide](/documentation/guides/usage/developing-testcontainers.md) to get access to comprehensive documentation regarding supported languages, configuration and demo applications.
+Please check our [Developing with Testcontainers guide](/documentation/guides/usage/developing-testcontainers/) to get access to comprehensive documentation regarding supported languages, configuration and demo applications.
 
 
 ### 2. Using Docker Desktop Extension

--- a/content/documentation/references/container-images.md
+++ b/content/documentation/references/container-images.md
@@ -62,7 +62,7 @@ The *Uber* distribution provide additional tags with `-native` suffix (`xyz-nati
 
 ### Microcks Uber Async Minion
 
-The Microcks Uber Async Minion (`microcks-uber-async-minion`) is responsible for publishing mock messages corresponding to [AsyncAPI](/documentation/references/artifacts/asyncapi-conventions) definitions with *Uber* distribution. It is produced from https://github.com/microcks/microcks/tree/master/distro/uber-async repo folder.
+The Microcks Uber Async Minion (`microcks-uber-async-minion`) is responsible for publishing mock messages corresponding to [AsyncAPI](/documentation/references/artifacts/asyncapi-conventions) definitions with *Uber* distribution. It is produced from https://github.com/microcks/microcks/tree/master/distro/uber-async-minion repo folder.
 
 | Repository | Pull command      | Available tags |
 | ---------- | ----------------- | -------------- |


### PR DESCRIPTION
## Description
Fixed broken link to Testcontainers guide in deployment options documentation.

## What was wrong
The link had `.md` extension: `/documentation/guides/usage/developing-testcontainers.md`

## Fix
Removed `.md` extension: `/documentation/guides/usage/developing-testcontainers/`

## Verification
- Old link (404): https://microcks.io/documentation/guides/usage/developing-testcontainers.md
- New link (200): https://microcks.io/documentation/guides/usage/developing-testcontainers/

Fixes #431