### PR TITLE
fix: correct Testcontainers guide link

### DIFF
--- a/content/documentation/explanations/deployment-options.md
+++ b/content/documentation/explanations/deployment-options.md
@@ -67,7 +67,7 @@ var microcks = new MicrocksContainer(DockerImageName.parse("quay.io/microcks/mic
 microcks.start();
 ```
 
-Please check our [Developing with Testcontainers guide](/documentation/guides/usage/developing-testcontainers.md) to get access to comprehensive documentation regarding supported languages, configuration and demo applications.
+Please check our [Developing with Testcontainers guide](/documentation/guides/usage/developing-testcontainers/) to get access to comprehensive documentation regarding supported languages, configuration and demo applications.
 
 
 ### 2. Using Docker Desktop Extension


### PR DESCRIPTION
Fixes #431

Signed-off-by: Mahitha Adapa <mahitha.ada@gmail.com>

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- Fixed broken link to Testcontainers guide in deployment options documentation
- Removed incorrect .md extension from URL
- Link now correctly points to /documentation/guides/usage/developing-testcontainers/

### Related issue(s)
Fixes #431
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->