### PR TITLE
fix: correct GitHub link to uber-async-minion

### DIFF
--- a/content/documentation/references/container-images.md
+++ b/content/documentation/references/container-images.md
@@ -33,7 +33,7 @@ The Microcks main web application (also called `webapp`) that holds the UI resou
 
 ### Microcks Async Minion
 
-The Microcks Async Minion (`microcks-async-minion`) is a component responsible for publishing mock messages corresponding to [AsyncAPI](/documentation/references/artifacts/asyncapi-conventions) definitions. It is produced from https://github.com/microcks/microcks/tree/master/minions/async repo folder.
+The Microcks Async Minion (`microcks-async-minion`) is a component responsible for publishing mock messages corresponding to [AsyncAPI](/documentation/references/artifacts/asyncapi-conventions) definitions. It is produced from https://github.com/microcks/microcks/tree/master/distro/uber-async-minion repo folder.
 
 | Repository | Pull command      | Available tags |
 | ---------- | ----------------- | -------------- |


### PR DESCRIPTION
Fixes #433

Signed-off-by: Mahitha Adapa <mahitha.ada@gmail.com>

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- Fixed broken GitHub link in container images documentation
- Added missing -minion suffix to uber-async path

### Related issue(s)
Fixes #433

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->