### PR TITLE
Docs: add complete “Using GitLab CI” guide and align with automation docs

### DIFF
--- a/content/documentation/guides/automation/gitlab.md
+++ b/content/documentation/guides/automation/gitlab.md
@@ -3,13 +3,145 @@ draft: false
 title: "Using GitLab CI"
 date: 2019-11-11
 publishdate: 2019-11-11
-lastmod: 2024-06-10
+lastmod: 2025-09-08
 weight: 7
 ---
 
-> 🪄 **To Be Created**
->
-> This is a new documentation page that has to be written as part of our [Refactoring Effort](https://github.com/microcks/microcks.io/issues/81).
-> 
-> **Goal of this page**
-> * ...
+## Overview
+
+This guide shows how to integrate Microcks within your GitLab CI pipelines. You will:
+
+- **Import** API [Artifacts](/documentation/references/artifacts/) (OpenAPI, Postman, AsyncAPI, etc.) into a Microcks instance
+- **Launch tests** against a deployed API endpoint to verify contract conformance
+
+We rely on the [Microcks CLI](/documentation/guides/automation/cli) executed via its container image inside GitLab CI jobs. Authentication uses a Microcks [Service Account](/documentation/explanations/service-account).
+
+## 1. Prerequisites
+
+- A running Microcks instance and its API URL, for example: `https://microcks.apps.acme.com/api/`
+- A Service Account client configured in your Microcks Keycloak realm, with its `client_id` and `client_secret`
+- A GitLab project where you can define CI variables
+
+We recommend storing credentials as masked GitLab CI variables:
+
+- `MICROCKS_URL` → Microcks API endpoint (must end with `/api/`)
+- `KEYCLOAK_CLIENT_ID` → Service Account client ID
+- `KEYCLOAK_CLIENT_SECRET` → Service Account client secret
+
+In your project, navigate to Settings → CI/CD → Variables and add the variables above. Mark credentials as masked and protected according to your workflow.
+
+## 2. Import job (push artifacts into Microcks)
+
+Use the `microcks-cli` container to import one or multiple specification files. Optionally mark artifacts as `primary` to drive multi-artifact behavior (see [Multi-artifacts](/documentation/explanations/multi-artifacts)).
+
+```yaml
+# .gitlab-ci.yml (excerpt)
+stages:
+  - import
+
+import-specs:
+  stage: import
+  image: quay.io/microcks/microcks-cli:latest
+  variables:
+    MICROCKS_URL: "$MICROCKS_URL"              # set at project/group level
+    KEYCLOAK_CLIENT_ID: "$KEYCLOAK_CLIENT_ID"  # set at project/group level
+    KEYCLOAK_CLIENT_SECRET: "$KEYCLOAK_CLIENT_SECRET" # set at project/group level
+  script:
+    - |
+      microcks-cli import \
+        'specs/weather-forecast-openapi.yml:true,specs/weather-forecast-postman.json:false' \
+        --microcksURL="$MICROCKS_URL" \
+        --keycloakClientId="$KEYCLOAK_CLIENT_ID" \
+        --keycloakClientSecret="$KEYCLOAK_CLIENT_SECRET"
+```
+
+Notes:
+
+- The argument to `import` is a comma-separated list of `<file[:primary]>` entries.
+- If you use self-signed certificates, add `--insecure`.
+
+## 3. Test job (run contract tests)
+
+Run a contract test against your deployed API endpoint with one of the supported runners (`HTTP`, `SOAP`, `SOAP_UI`, `POSTMAN`, `OPEN_API_SCHEMA`, `ASYNC_API_SCHEMA`).
+
+```yaml
+# .gitlab-ci.yml (excerpt)
+stages:
+  - test
+
+test-api-contract:
+  stage: test
+  image: quay.io/microcks/microcks-cli:latest
+  variables:
+    MICROCKS_URL: "$MICROCKS_URL"
+    KEYCLOAK_CLIENT_ID: "$KEYCLOAK_CLIENT_ID"
+    KEYCLOAK_CLIENT_SECRET: "$KEYCLOAK_CLIENT_SECRET"
+  script:
+    - |
+      microcks-cli test \
+        'API Pastry - 2.0:2.0.0' \
+        'https://my-api-pastry.apps.example.com' \
+        OPEN_API_SCHEMA \
+        --microcksURL="$MICROCKS_URL" \
+        --keycloakClientId="$KEYCLOAK_CLIENT_ID" \
+        --keycloakClientSecret="$KEYCLOAK_CLIENT_SECRET" \
+        --waitFor=10sec
+```
+
+Notes:
+
+- The first three arguments are: `<apiName:apiVersion>` `<testEndpoint>` `<runner>`.
+- `--waitFor` lets the job wait for test completion up to the specified duration.
+- Add `--insecure` if your Microcks endpoint uses self-signed certificates.
+
+## 4. End-to-end example pipeline
+
+Below is a minimal pipeline with two stages: import artifacts and test the deployed API. Adapt the `only/except` or `rules` to your workflow.
+
+```yaml
+# .gitlab-ci.yml
+stages: [import, test]
+
+variables:
+  # Prefer defining these at project/group level in Settings → CI/CD → Variables
+  MICROCKS_URL: "$MICROCKS_URL"
+  KEYCLOAK_CLIENT_ID: "$KEYCLOAK_CLIENT_ID"
+  KEYCLOAK_CLIENT_SECRET: "$KEYCLOAK_CLIENT_SECRET"
+
+import-specs:
+  stage: import
+  image: quay.io/microcks/microcks-cli:latest
+  script:
+    - microcks-cli version
+    - |
+      microcks-cli import \
+        'specs/weather-forecast-openapi.yml:true,specs/weather-forecast-postman.json:false' \
+        --microcksURL="$MICROCKS_URL" \
+        --keycloakClientId="$KEYCLOAK_CLIENT_ID" \
+        --keycloakClientSecret="$KEYCLOAK_CLIENT_SECRET"
+  rules:
+    - if: $CI_COMMIT_BRANCH
+
+test-api-contract:
+  stage: test
+  image: quay.io/microcks/microcks-cli:latest
+  needs: ["import-specs"]
+  script:
+    - |
+      microcks-cli test \
+        'API Pastry - 2.0:2.0.0' \
+        'https://my-api-pastry.apps.example.com' \
+        OPEN_API_SCHEMA \
+        --microcksURL="$MICROCKS_URL" \
+        --keycloakClientId="$KEYCLOAK_CLIENT_ID" \
+        --keycloakClientSecret="$KEYCLOAK_CLIENT_SECRET" \
+        --waitFor=10sec
+  rules:
+    - if: $CI_COMMIT_BRANCH
+```
+
+## Wrap-up
+
+You have learned how to use the `microcks-cli` inside GitLab CI to import API artifacts and run contract tests. The CLI reuses the same authentication foundation described in the [Automation API guide](/documentation/guides/automation/api) and relies on a [Service Account](/documentation/explanations/service-account). For CLI flags and options, check the [Microcks CLI](/documentation/guides/automation/cli) guide and the tool's README.
+
+If you prefer a native CI integration, see also the guides for [GitHub Actions](/documentation/guides/automation/github-actions) and [Jenkins](/documentation/guides/automation/jenkins).

--- a/content/documentation/guides/integration/microcks-hub.md
+++ b/content/documentation/guides/integration/microcks-hub.md
@@ -1,15 +1,92 @@
----
 draft: false
 title: "Integrating with Microcks Hub"
 date: 2024-04-30
 publishdate: 2024-04-30
-lastmod: 2024-04-30
+lastmod: 2025-08-24
 weight: 2
 ---
 
-> 🪄 **To Be Created**
->
-> This is a new documentation page that has to be written as part of our [Refactoring Effort](https://github.com/microcks/microcks.io/issues/81).
-> 
-> **Goal of this page**
-> * ...
+## Overview
+
+Microcks Hub is a community hub and free marketplace where API producers publish ready‑to‑use API mocks and test suites for Microcks. From any Microcks instance, you can browse the Hub, discover API Packages, and install versions in one click to quickly provision mocks and conformance tests.
+
+- **Hub URL**: `https://hub.microcks.io`
+- **What you get**: OpenAPI/AsyncAPI/GraphQL/gRPC artifacts, Postman tests, curated as installable API Packages
+- **Typical use cases**: try APIs, build sandboxes, validate upgrades, run conformance testing
+
+The Hub is enabled by default in Microcks and appears as a menu entry in the left navigation.
+
+## 1. Prerequisites
+
+- A running Microcks instance (local or cluster). See [Installation guides](/documentation/guides/installation/).
+- A user with a role allowed to use the Hub menu (see Roles below).
+
+## 2. Enable or disable the Hub
+
+Hub integration is controlled by `features.properties` and is enabled by default. Administrators can configure the endpoint and restrict access to specific roles.
+
+### Raw properties (Docker/Podman Compose)
+
+Mount a `features.properties` file into the `microcks` container (see [Application Configuration reference](/documentation/references/configuration/application-config/#hub-access)) and define:
+
+```properties
+features.feature.microcks-hub.enabled=true
+features.feature.microcks-hub.endpoint=https://hub.microcks.io/api
+features.feature.microcks-hub.allowed-roles=admin,manager,manager-any
+```
+
+- Set `enabled=false` to hide the Hub entry from the UI.
+- Adjust `allowed-roles` to match your access policy. `manager-any` means any user who belongs to at least one management group.
+
+### Helm Chart
+
+Use the `values.yaml` equivalent under `features.microcksHub` (see [Helm Chart config](/documentation/references/configuration/helm-chart-config)) to enable/disable and set endpoint/roles.
+
+### Kubernetes Operator
+
+Use the `Microcks` Custom Resource under `spec.features.microcksHub` (see [Operator config](/documentation/references/configuration/operator-config)).
+
+## 3. Browse and install from the Hub
+
+1. In Microcks, open the left menu and click `Microcks Hub`.
+2. Browse available tiles. For a quick start, pick `MicrocksIO Samples API` to import sample APIs.
+3. Click an API Package to open its details and select the API Version you need.
+4. Click `Install` and choose an import method:
+   - **Direct import**: immediately imports artifacts into your repository.
+   - **Create Importer**: sets up a scheduled Importer to keep in sync from source control or remote URLs.
+5. On success, follow the `Go` link to open the imported API or find it under `APIs | Services`.
+
+Refer to the Getting Started tutorial for screenshots of the Hub entry and flow: see [Loading a Sample](/documentation/tutorials/getting-started/#loading-a-sample).
+
+## 4. Roles and permissions
+
+Access to the Hub UI is restricted to users whose role is included in `features.feature.microcks-hub.allowed-roles`.
+
+- Default: `admin,manager,manager-any`
+- Set an empty or stricter list to reduce access surface.
+
+Imported artifacts follow your repository labels, segmentation and permissions. See [Organizing Repository](/documentation/guides/administration/organizing-repository/).
+
+## 5. Network and connectivity
+
+Microcks connects to the Hub backend via the configured `endpoint` (default `https://hub.microcks.io/api`). Ensure outbound egress is allowed for the Microcks Webapp pod/container. If you use a proxy, configure JVM/system proxy settings accordingly.
+
+## 6. Troubleshooting
+
+- Hub menu missing: verify `features.feature.microcks-hub.enabled=true` and that your user has an allowed role.
+- Cannot reach the Hub: check egress/firewall/proxy rules and `endpoint` URL. Test from the host/container with `curl`.
+- Install fails: open the package page and prefer `Direct import` first; if using `Create Importer`, validate credentials/secrets and artifact URLs.
+- Permissions: confirm repository labels/segmentation do not prevent visibility or management actions.
+
+## 7. Related resources
+
+- Blog announcement: [Microcks’ hub and marketplace](/blog/microcks-hub-announcement/)
+- Contribution guide (publish your Package): `https://hub.microcks.io/doc/how-to-contribute`
+- Package model and examples: `https://hub.microcks.io/doc/package-api-mocks`
+- Getting started tutorial: [Using Microcks Hub](/documentation/tutorials/getting-started/#loading-a-sample)
+- Application configuration reference: [Hub Access](/documentation/references/configuration/application-config/#hub-access)
+
+## 8. FAQ
+
+- Is the Hub a Postman alternative? No. The Hub complements Postman by distributing mocks and conformance suites for enterprise workflows. See the [announcement](/blog/microcks-hub-announcement/#enthusiastic) for details.
+- Can I run a private Hub? The built‑in integration targets the public Hub. For private catalogs, rely on Importers pointing to your internal repositories.

--- a/content/documentation/guides/integration/microcks-hub.md
+++ b/content/documentation/guides/integration/microcks-hub.md
@@ -62,7 +62,7 @@ Refer to the Getting Started tutorial for screenshots of the Hub entry and flow:
 
 Access to the Hub UI is restricted to users whose role is included in `features.feature.microcks-hub.allowed-roles`.
 
-- Default: `admin,manager,manager-any`
+- Default: `admin`
 - Set an empty or stricter list to reduce access surface.
 
 Imported artifacts follow your repository labels, segmentation and permissions. See [Organizing Repository](/documentation/guides/administration/organizing-repository/).
@@ -90,3 +90,6 @@ Microcks connects to the Hub backend via the configured `endpoint` (default `htt
 
 - Is the Hub a Postman alternative? No. The Hub complements Postman by distributing mocks and conformance suites for enterprise workflows. See the [announcement](/blog/microcks-hub-announcement/#enthusiastic) for details.
 - Can I run a private Hub? The built‑in integration targets the public Hub. For private catalogs, rely on Importers pointing to your internal repositories.
+
+  > **Note:** Running a private Hub is a common community request and is currently a work in progress.  
+  > We welcome contributions on this feature: [GitHub Issue #118](https://github.com/microcks/hub.microcks.io/issues/118).


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
### PR Title
docs: add complete “Using GitLab CI” guide and align with automation docs

### Summary
Adds a full GitLab CI guide to replace the placeholder page, ensuring consistency with GitHub Actions and CLI guides. The page covers overview, prerequisites, secure variables, import and test jobs using `microcks-cli`, and a minimal end-to-end pipeline.

### What’s changed
- Replaced placeholder in `content/documentation/guides/automation/gitlab.md` with complete content
- Added:
  - Overview and prerequisites
  - GitLab CI variables/secrets guidance
  - Import job example (multi-artifact, primary flag)
  - Test job example (runners, waitFor, insecure note)
  - End-to-end `.gitlab-ci.yml` pipeline
  - Wrap-up with cross-links to CLI, API, GitHub Actions, Jenkins

### Related issue(s)

- Relates to discussion in #415 (comment)
- Progress toward refactoring effort (see references mentioned within the page)