### PR TITLE
fix: add redirect for /documentation/getting-started/ to /documentation/tutorials/getting-started/

### DIFF
--- a/content/documentation/getting-started/_index.md
+++ b/content/documentation/getting-started/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Getting started"
+layout: "redirect"
+target: "/documentation/tutorials/getting-started/"
+---


### PR DESCRIPTION
## Problem
The URL `https://microcks-io.vercel.app/documentation/getting-started/` returns a 404 error. Users trying to access the shorter URL path encounter a broken link.

## Solution
Added a redirect file that automatically redirects requests from `/documentation/getting-started/` to the correct location at `/documentation/tutorials/getting-started/`.

## Changes
- Created `content/documentation/getting-started/_index.md` with redirect layout
- Uses Hugo's built-in redirect template to provide a clean HTTP redirect

## Testing
After merge, the following URL should redirect properly:
- `https://microcks.io/documentation/getting-started/` → `https://microcks.io/documentation/tutorials/getting-started/`

## Type of Change
- [x] Bug fix (broken link fix)