### PR TITLE
fix: link in microcks-1.2.0-release.md. 

### DIFF
--- a/content/blog/microcks-1.2.0-release.md
+++ b/content/blog/microcks-1.2.0-release.md
@@ -81,6 +81,6 @@ We have many plans for the coming months but will be very happy to prioritize de
 * community sharing of mocks and tests for regulatory or industrial standards,
 * more metrics and analytics to govern your APIs with Microcks.
 
-Remember that we are open and it means that you can jump on board to make Microcks even greater! Come and say hi! on our [Discord chat](https://microcks.io/discord-invite/) 🐙 , simply send some love through [GitHub stars]([https://github.com/microcks/microcks) ⭐️ or follow us on [Twitter]([https://twitter.com/microcksio).
+Remember that we are open and it means that you can jump on board to make Microcks even greater! Come and say hi! on our [Discord chat](https://microcks.io/discord-invite/) 🐙, simply send some love through [GitHub stars](https://github.com/microcks/microcks) ⭐️ or follow us on [X](https://x.com/microcksio).
 
 Thanks for reading and supporting us! Stay safe and healthy. ❤️  


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- Fixes broken markdown links in the Microcks 1.2.0 release blog post by removing extra '[' before URLs and updating Twitter to X.
- closes #479 
### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->