### PR TITLE
fix: update broken SoapUI projects link in Artifacts reference

### DIFF
--- a/content/documentation/references/artifacts/_index.md
+++ b/content/documentation/references/artifacts/_index.md
@@ -13,7 +13,7 @@ Microcks supports the following specifications and tooling file formats as artif
 
 We provide built-in parsers and importers for the following formats:
 
-* [SoapUI projects](https://www.soapui.org/soapui-projects/soapui-projects.html) files starting with version 5.1 of SoapUI. See the Microcks' [SoapUI Conventions](./soapui-conventions),
+* [SoapUI projects](https://www.soapui.org/docs/getting-started/projects/working-with-projects/) files starting with version 5.1 of SoapUI. See the Microcks' [SoapUI Conventions](./soapui-conventions),
 * [Swagger v2](https://swagger.io/specification/v2/) files. See the Microcks' [Swagger Conventions](./swagger-conventions),
 * [OpenAPI v3.x](https://spec.openapis.org/) files in either YAML or JSON format. See the Microcks' [OpenAPI Conventions](./openapi-conventions),
 * [AsyncAPI v2.x](https://v2.asyncapi.com/docs/reference/specification/v2.6.0) and [AsyncAPI v3.x](https://www.asyncapi.com/docs/reference/specification/v3.0.0) files in either YAML or JSON format. See the Microcks' [AsyncAPI Conventions](./asyncapi-conventions),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- The previous SoapUI projects link (/soapui-projects/soapui-projects.html) returned 404 due to changes in SoapUI’s documentation structure.
- Updated the reference to the current “Working with Projects” documentation page, which describes SoapUI project files and matches the original intent of the section.
- closes #491 

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->