### PR TITLE
docs: fix broken Keycloak securing_apps documentation link

### DIFF
--- a/content/documentation/references/configuration/security-config.md
+++ b/content/documentation/references/configuration/security-config.md
@@ -77,7 +77,7 @@ These roles are:
 * `manager`: a user identified as having management roles on the Microcks repository content. Managers have the permissions of adding and removing API & Services into the repository as well as configuring mocks operation properties
 * `admin`: a user identified as having administration role on the Microcks instance. Admin have the `manager` persmission and are able to manage users, configure external repositories secrets or realize backup/restore operations.
 
-Whether a connected user has these roles is checked both on the client and the server sides using [Keycloak adapters](https://www.keycloak.org/docs/latest/securing_apps/index.html).
+Whether a connected user has these roles is checked both on the client and the server sides using [Keycloak adapters](https://www.keycloak.org/guides#securing-apps).
 
 #### Groups segmentation
 


### PR DESCRIPTION
### Description

- Fixed broken link to Keycloak documentation for securing apps
- Updated from old docs URL to new Keycloak guides structure:
  - Old: `https://www.keycloak.org/docs/latest/securing_apps/index.html` (404)
  - New: `https://www.keycloak.org/guides#securing-apps` (working)

### Related issue(s)

Fixes #492