### PR TITLE
docs: fix missing https scheme in hub.microcks.io link

### DIFF
--- a/content/blog/microcks-1.5.2-release.md
+++ b/content/blog/microcks-1.5.2-release.md
@@ -21,7 +21,7 @@ Let’s do a quick review of what’s new.
 
 ## Hub integration FTW!
 
-[hub.microcks.io](hub.microcks.io) and Microcks are now fully integrated and you can take all advantages of our new community hub and free marketplace where ever you need: **on-premise**, in the **cloud**, or go **fully hybrid** 👍 \
+[hub.microcks.io](https://hub.microcks.io) and Microcks are now fully integrated and you can take all advantages of our new community hub and free marketplace where ever you need: **on-premise**, in the **cloud**, or go **fully hybrid** 👍 \
  \
 A new `Microcks Hub` menu entry is now available by default in the vertical navigation bar. Access to this new entry can of course be restricted to certain roles in your organization or totally removed if needed (by setting the ``microcksHub.enabled`` property to `false`).
 


### PR DESCRIPTION
### Description

- Fixed broken link to hub.microcks.io in Microcks 1.5.2 release blog post
- Added missing `https://` scheme to make it an external link:
  - Old: `[hub.microcks.io](hub.microcks.io)` (relative link - 404)
  - New: `[hub.microcks.io](https://hub.microcks.io)` (external link - working)

### Related issue(s)

Fixes #489