### PR TITLE
fix: broken UUID RFC 4122 reference link in Mock Templates documentation

### DIFF
--- a/content/documentation/references/templates.md
+++ b/content/documentation/references/templates.md
@@ -177,7 +177,7 @@ $timestamp  // 1581425292309
 
 #### UUID generator
 
-The `uuid()` function allows to simply generate a UUID compliant with RFC 4122 (see https://www.cryptosys.net/pki/uuid-rfc4122.html). It can also be invoked using the `guid()` or `randomUUID()`. 
+The `uuid()` function allows to simply generate a UUID compliant with RFC 4122 (see [https://www.cryptosys.net/pki/uuid-rfc4122.html](https://www.cryptosys.net/pki/uuid-rfc4122.html)). It can also be invoked using the `guid()` or `randomUUID()`. 
 
 ```js
 uuid() // 3F897E85-62CE-4B2C-A957-FCF0CCE649FD


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fixes broken UUID RFC 4122 reference link in Mock Templates documentation by correcting Markdown link formatting so the URL no longer includes the closing parenthesis and resolves correctly.
- closes #493

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->