### PR TITLE
fix: gRPC Conventions link in documentation

### DIFF
--- a/content/documentation/references/artifacts/_index.md
+++ b/content/documentation/references/artifacts/_index.md
@@ -18,7 +18,7 @@ We provide built-in parsers and importers for the following formats:
 * [OpenAPI v3.x](https://spec.openapis.org/) files in either YAML or JSON format. See the Microcks' [OpenAPI Conventions](./openapi-conventions),
 * [AsyncAPI v2.x](https://v2.asyncapi.com/docs/reference/specification/v2.6.0) and [AsyncAPI v3.x](https://www.asyncapi.com/docs/reference/specification/v3.0.0) files in either YAML or JSON format. See the Microcks' [AsyncAPI Conventions](./asyncapi-conventions),
 * [Postman collections](https://www.postman.com/collection/) files with v2.x file format,
-* [gRPC / Protocol buffers v3](https://grpc.io/docs/what-is-grpc/introduction/) `.proto` files. See the Microcks' [gRPC Conventions](./gRPC-conventions),
+* [gRPC / Protocol buffers v3](https://grpc.io/docs/what-is-grpc/introduction/) `.proto` files. See the Microcks' [gRPC Conventions](https://microcks.io/documentation/references/artifacts/grpc-conventions/),
 * [GraphQL Schema](https://graphql.org/learn/schema/) `.graphql` files. See the Microcks' [GraphQL Conventions](./graphql-conventions),
 * [HTTP Archive Format (HAR)](https://w3c.github.io/web-performance/specs/HAR/Overview.html) JSON files. See the Microcks' [HAR Conventions](./har-conventions),
 


### PR DESCRIPTION
Updated the link for gRPC Conventions to the correct documentation page.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- The Artifacts Reference page contains a broken link to the gRPC conventions documentation (./gRPC-conventions), which returns a 404. This PR updates the link to the correct and currently valid page:
https://microcks.io/documentation/references/artifacts/grpc-conventions/
- closes #483 

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->