### PR TITLE
Fix broken Wikipedia link in alternatives page

### DIFF
--- a/content/documentation/overview/alternatives.md
+++ b/content/documentation/overview/alternatives.md
@@ -10,7 +10,7 @@ weight: 4
 > <br/> <strong>Comparison with alternatives is always a tough question 🤔</strong>
 
 Please check this **neutral Wikipedia page** for more insights:
-[Comparison of API simulation tools](https://en.wikipedia.org/wiki/Service_virtualization)
+[Comparison of API simulation tools](https://en.everybodywiki.com/Comparison_of_API_simulation_tools)
 
 If you would like a more opinionated description on _"How Microcks **compares to Pact for Contract Testing**?"_, you may want to read this [Medium blog](https://medium.com/@lbroudoux/) post by one of the project co-founder: [Microcks and Pact for API contract testing](https://medium.com/@lbroudoux/microcks-and-pact-for-api-contract-testing-3e0e7d4516ca).
 


### PR DESCRIPTION
### Description
The "Comparison of API simulation tools" page on Wikipedia was deleted. I replaced the broken link with the "Service Virtualization" page, which is the correct industry term for these tools.

### Related issue(s)
Fixes #490