### PR TITLE
Fix Async API link in test-endpoints.md

### DIFF
--- a/content/documentation/references/test-endpoints.md
+++ b/content/documentation/references/test-endpoints.md
@@ -86,7 +86,7 @@ The `/{service.path}` may be optioanl if your target API is deployed on the root
 
 ### Event based APIs
 
-For Event based API through [Async API](../asyncapi) testing, pattern is depending on the protocole binding you'd like to test.
+For Event based API through [Async API](/documentation/references/apis/async-api) testing, pattern is depending on the protocole binding you'd like to test.
 
 #### Kafka 
 


### PR DESCRIPTION
Corrected the link to Async API documentation.

https://microcks.io/documentation/references/apis/async-api/

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

- Fix Async API link in test-endpoints.md

### Related issue(s)

https://github.com/microcks/microcks.io/issues/482

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->