### PR TITLE
fix: link to templating expressions in direct-api.md

### DIFF
--- a/content/documentation/guides/usage/direct-api.md
+++ b/content/documentation/guides/usage/direct-api.md
@@ -163,7 +163,7 @@ Direct API is also able to manage Event Driven API that are described using Asyn
 <br/>
 </div>
 
-Then adding a reference JSON payload - such a payload can also include some [templating expressions](./advanced/templates) to get some more dynamic data. Here we define producing random stock symbols and range price values:
+Then adding a reference JSON payload - such a payload can also include some [templating expressions](/documentation/references/templates/) to get some more dynamic data. Here we define producing random stock symbols and range price values:
 
 <div align="center">
 <br/>


### PR DESCRIPTION
Updated the link to the templating expressions documentation for accuracy.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description
- fixes broken relative link ./advanced/templates in Direct API guide
- updates it to /documentation/references/templates/, which is the current location of templates documentation
- closes #486

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->