### PR TITLE
docs: fix contextualized key typo in async trigger example

### DIFF
--- a/content/documentation/explanations/async-triggers.md
+++ b/content/documentation/explanations/async-triggers.md
@@ -85,7 +85,7 @@ channels:
         description: An event describing that a user just signed up.
         # [...]
         examples:
-          - constextualized:
+          - contextualized:
               headers:
                 my-app-header: 25
               payload:


### PR DESCRIPTION
## Summary
- fix a typo in the Async Triggers docs under Specifying Contextualized Messages
- rename the YAML key from constextualized to contextualized in the example block

Fixes #531