### PR TITLE
docs: fix typo in Specifying Contextualized Messages section

### DIFF
--- a/content/documentation/explanations/async-triggers.md
+++ b/content/documentation/explanations/async-triggers.md
@@ -85,7 +85,7 @@ channels:
         description: An event describing that a user just signed up.
         # [...]
         examples:
-          - constextualized:
+          - contextualized:
               headers:
                 my-app-header: 25
               payload:


### PR DESCRIPTION
Fixes #531.

This PR fixes a small typo in the documentation for asynchronous triggers. The word `constextualized` was misspelled in a code block and has been corrected to `contextualized`.