### PR TITLE
feat: add netlify.toml for PR deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,47 @@
+[build]
+  publishDir = "public"
+
+[build.environment]
+  HUGO_VERSION = "0.123.0"
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/docs/*"
+  to = "/documentation/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/blog/*"
+  to = "/blog/:splat"
+  status = 301
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+[[headers]]
+  for = "*.js"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "*.css"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "*.png"
+  [headers.values]
+    Cache-Control = "public, max-age=2592000"
+
+[context.production.environment]
+  HUGO_ENV = "production"
+
+[context.deploy-preview.environment]
+  HUGO_ENV = "preview"
+
+[context.branch-deploy.environment]
+  HUGO_ENV = "staging"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,53 @@
   publish = "public"
   command = "npm run build"
 
+[build.environment]
+  HUGO_VERSION = "0.123.0"
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/docs/*"
+  to = "/documentation/:splat"
+  status = 301
+
+[[redirects]]
+  from = "/blog/*"
+  to = "/blog/:splat"
+  status = 301
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+
+[[headers]]
+  for = "*.js"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "*.css"
+  [headers.values]
+    Cache-Control = "public, max-age=31536000"
+
+[[headers]]
+  for = "*.png"
+  [headers.values]
+    Cache-Control = "public, max-age=2592000"
+
 [context.deploy-preview]
   command = "npm run build"
 
+[context.deploy-preview.environment]
+  HUGO_ENV = "preview"
+
 [context.branch-deploy]
   command = "npm run build"
+
+[context.branch-deploy.environment]
+  HUGO_ENV = "staging"
 
 [context.production]
   command = "npm run build"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

Improve the contribution experience by making PR reviews faster and more efficient. This addresses issue #334 where the community requested Netlify preview setup.

This PR adds a `netlify.toml` configuration file to enable Netlify's deploy preview functionality:
- Build settings with Hugo version specification
- Redirect rules for backward compatibility (/docs/*, /blog/*)
- Security headers (X-Frame-Options, X-Content-Type-Options)
- Cache headers for assets (JS, CSS, images)
- Environment-specific settings for production, preview, and staging

### Related issue(s)

#334 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->