### PR TITLE
feat: add robots.txt for SEO and bot management

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,10 @@
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+Sitemap: https://microcks.io/sitemap.xml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

The site currently lacks a robots.txt file, which means search engines have no guidance on how to crawl the site. Additionally, AI training bots like GPTBot are actively crawling sites without consent.

Improve SEO performance and respect content licensing. Issue #209 specifically mentions enhancing SEO and analytics for better search engine ranking.

This PR adds a robots.txt file that:
- Allows all standard crawlers access to the site
- Explicitly blocks GPTBot and CCBot (AI training crawlers)
- References the XML sitemap for search engines

### Related issue(s)

#209 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->