### PR TITLE
feat: add canonical URLs and meta tags for SEO

### DIFF
--- a/themes/microcks/layouts/partials/head.html
+++ b/themes/microcks/layouts/partials/head.html
@@ -1,8 +1,19 @@
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>{{.Title | default site.Title}}</title>
 
+{{- if .Params.canonical }}
+<link rel="canonical" href="{{ .Params.canonical }}" />
+{{- else }}
+<link rel="canonical" href="{{ .Permalink }}" />
+{{- end -}}
+
+
+
 <!-- responsive meta -->
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1, maximum-scale=5"
+/>
 
 <meta name="theme-name" content="bigspring-hugo" />
 
@@ -16,7 +27,10 @@
 {{ partialCached "site-verifications.html" . }}
 
 <!-- opengraph and twitter card -->
-{{ partial "basic-seo.html" . }}
+{{ partial "basic-seo.html" . }} {{- if and .IsPage (not .Draft) -}} {{- if
+templates.Exists "partials/single.jsonld" -}} {{- partial "single.jsonld" . -}}
+{{- else if fileExists "layouts/_default/single.jsonld" -}} {{- partial
+"_default/single.jsonld" . -}} {{- end -}} {{- end -}}
 
 <!-- custom script -->
 {{ partialCached "custom-script.html" . }}

--- a/themes/microcks/layouts/partials/head.html
+++ b/themes/microcks/layouts/partials/head.html
@@ -1,8 +1,28 @@
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <title>{{.Title | default site.Title}}</title>
 
+{{- if .Params.canonical }}
+<link rel="canonical" href="{{ .Params.canonical }}" />
+{{- else }}
+<link rel="canonical" href="{{ .Permalink }}" />
+{{- end -}}
+
+<meta
+  name="description"
+  content="{{ with .Description }}{{ . }}{{ else }}{{ with .Summary }}{{ . }}{{ else }}{{ site.Params.description }}{{ end }}{{ end }}"
+/>
+
+{{- if .Keywords }}
+<meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}" />
+{{- end }} {{- if .Params.author }}
+<meta name="author" content="{{ .Params.author }}" />
+{{- end }}
+
 <!-- responsive meta -->
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5">
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1, maximum-scale=5"
+/>
 
 <meta name="theme-name" content="bigspring-hugo" />
 
@@ -16,7 +36,10 @@
 {{ partialCached "site-verifications.html" . }}
 
 <!-- opengraph and twitter card -->
-{{ partial "basic-seo.html" . }}
+{{ partial "basic-seo.html" . }} {{- if and .IsPage (not .Draft) -}} {{- if
+templates.Exists "partials/single.jsonld" -}} {{- partial "single.jsonld" . -}}
+{{- else if fileExists "layouts/_default/single.jsonld" -}} {{- partial
+"_default/single.jsonld" . -}} {{- end -}} {{- end -}}
 
 <!-- custom script -->
 {{ partialCached "custom-script.html" . }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

Without canonical URLs, search engines may index duplicate content from different URL variations (with/without trailing slashes, different case, etc.). This dilutes page authority and can hurt rankings.

SEO enhancement requested in issue #209. Canonical tags are essential for any professional website to ensure proper search engine indexing.

This PR adds to the head.html partial:
- Canonical URL link tags pointing to the canonical permalink
- Meta description with fallback to summary/site description
- Meta keywords support (for engines that still use them)
- Author meta tag for bylines

### How will this change help?
- Consolidate link equity to preferred URLs
- Prevent duplicate content issues
- Provide explicit metadata for search engines
- Improve keyword targeting with proper description and keywords meta

### Related issue(s)

#209 

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->