### PR TITLE
docs: fix spelling mistakes causing CI failure

### DIFF
--- a/content/documentation/explanations/async-triggers.md
+++ b/content/documentation/explanations/async-triggers.md
@@ -58,9 +58,9 @@ The important things to notice here:
 Specifying a trigger using above notation has the following consequences:
 
 1. Upon the execution of a mock for the `POST /register` operation, the original request and response will be captured before the response is sent back to the caller,
-2. Request and response will then be transfered asynchronously to the [Microcks Aync Minion component](/documentation/explanations/deployment-options/#complete-logical-architecture) with the information on the services, versions and operations to trigger,
+2. Request and response will then be transferred asynchronously to the [Microcks Aync Minion component](/documentation/explanations/deployment-options/#complete-logical-architecture) with the information on the services, versions and operations to trigger,
 3. The Async Minion will then take care of selecting the appropriate asynchronous service operatino and will try to find a **contextualized message** within this operation,
-4. If such a **contextualized message** is found, then it will be rendered and it will be sent over all the procotol bindings that are available for this asynchronous service (Kafka, WebSocket, etc.)
+4. If such a **contextualized message** is found, then it will be rendered and it will be sent over all the protocol bindings that are available for this asynchronous service (Kafka, WebSocket, etc.)
 
 Now you may wonder: what is a **contextualized message**? 🧐
 

--- a/content/documentation/guides/usage/openapi-webhooks.md
+++ b/content/documentation/guides/usage/openapi-webhooks.md
@@ -24,7 +24,7 @@ Let's take the example of a Petstore event stream for new pets registration! ðŸ›
 
 ## 1. An Example
 
-The `Petstore Webhooks` API declares a single webhook to allow consumers to receive information about new pets avaialble into our store. A pet definition is simplictic here: it has an `id`, a `name` and a `tag` (either a cat or a dog).
+The `Petstore Webhooks` API declares a single webhook to allow consumers to receive information about new pets available into our store. A pet definition is simplistic here: it has an `id`, a `name` and a `tag` (either a cat or a dog).
 
 Bolow is an example on how you would define this with OpenAPI Spec. You can get our full [`Petstore-webhooks-openapi.yaml`](https://github.com/microcks/microcks/blob/1.13.x/samples/Petstore-webhooks-openapi.yaml) file from our samples.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

This PR fixes a few minor spelling mistakes in the documentation that were causing the `misspell` CI check to fail. 
Fixed the following typos:
- `transfered` -> `transferred` (in `async-triggers.md`)
- `procotol` -> `protocol` (in `async-triggers.md`)
- `avaialble` -> `available` (in `openapi-webhooks.md`)
- `simplictic` -> `simplistic` (in `openapi-webhooks.md`)

I've attached a screenshot of the CI failure log below for reference:
<img width="1542" height="216" alt="Screenshot from 2026-05-26 15-05-37" src="https://github.com/user-attachments/assets/fe03e042-9611-4845-bee5-1717811bd701" />


### Related issue(s)
None

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->