### PR TITLE
Fix:Broken External Footer Links due to relLangURL Filter

### DIFF
--- a/themes/microcks/layouts/partials/footer.html
+++ b/themes/microcks/layouts/partials/footer.html
@@ -13,7 +13,11 @@
           <ul class="list-unstyled footer-list">
             {{ range site.Menus.footer_left }}
               <li>
-                <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ if (urls.Parse .URL).IsAbs }}
+                  <a href="{{ .URL | safeURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ else }}
+                  <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ end }}
               </li>
             {{ end }}
           </ul>
@@ -25,7 +29,11 @@
           <ul class="list-unstyled footer-list">
             {{ range site.Menus.footer_middle }}
               <li>
-                <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ if (urls.Parse .URL).IsAbs }}
+                  <a href="{{ .URL | safeURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ else }}
+                  <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ end }}
               </li>
             {{ end }}
           </ul>
@@ -37,9 +45,13 @@
           <ul class="list-unstyled footer-list">
             {{ range site.Menus.footer_right }}
               <li>
-                <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ if (urls.Parse .URL).IsAbs }}
+                  <a href="{{ .URL | safeURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ else }}
+                  <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
+                {{ end }}
               </li>
-              {{ end }}
+            {{ end }}
           </ul>
           {{ end }}
       </div>

--- a/themes/microcks/layouts/partials/header.html
+++ b/themes/microcks/layouts/partials/header.html
@@ -97,7 +97,11 @@
               </li>
             {{ else }}
               <li class="nav-item {{ if $active }}active{{ end }}">
-                <a class="nav-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+                {{ if (urls.Parse .URL).IsAbs }}
+                  <a class="nav-link" href="{{ .URL | safeURL }}">{{ .Name }}</a>
+                {{ else }}
+                  <a class="nav-link" href="{{ .URL | relLangURL }}">{{ .Name }}</a>
+                {{ end }}
               </li>
             {{ end }}
           {{ end }}
@@ -143,7 +147,8 @@
 
         {{ if site.Params.navigation_button.enable }}
         <!-- navigation btn -->
-        <a href="{{ site.Params.navigation_button.link | relLangURL }}"
+        {{ $navBtnLink := site.Params.navigation_button.link }}
+        <a href="{{ if (urls.Parse $navBtnLink).IsAbs }}{{ $navBtnLink | safeURL }}{{ else }}{{ $navBtnLink | relLangURL }}{{ end }}"
           class="btn btn-sm btn-primary ms-lg-4 mt-2 mt-lg-0">{{ site.Params.navigation_button.label }}</a>
         {{ end }}
 


### PR DESCRIPTION
Closes #554 
### Description
The footer layout filters external absolute menu links using the `relLangURL` filter.

* **File Link:** [themes/microcks/layouts/partials/footer.html](file:///c:/Users/Hp/microcks.io/themes/microcks/layouts/partials/footer.html#L28) and (file:///c:/Users/Hp/microcks.io/themes/microcks/layouts/partials/footer.html#)
* **Code Snippet:**
  ```html
  <a href="{{ .URL | relLangURL }}" title="{{ .Name }}">{{ .Name }}</a>
  ```

### Why It Breaks
The footer contains absolute external links, such as the Linux Foundation privacy policy URL: `https://www.linuxfoundation.org/legal/privacy-policy`. Passing this absolute URL into the `relLangURL` filter corrupts the URL into a malformed relative path prefix (e.g. `/https:/www.linuxfoundation.org/legal/privacy-policy`). Clicking this link causes a 404 error on the local host instead of opening the external web page.

### How to Reproduce
1. Build the website and scroll to the footer.
2. Click on the "Privacy Policy" or "Terms & Conditions" links.
3. Observe that the browser redirects to a broken 404 page on `microcks.io` rather than the external Linux Foundation website.

### issue Flow
```mermaid
sequenceDiagram
    actor User as Site Visitor
    participant Site as Footer Link
    participant Browser as Web Browser
    User->>Site: Clicks "Privacy Policy"
    Note over Site: Evaluates URL: "https://www.linuxfoundation.org/..." | relLangURL
    Site->>Browser: Opens "/https:/www.linuxfoundation.org/legal/privacy-policy"
    Browser->>Browser: Requests host web server
    Browser-->>User: Renders 404 Not Found Page
```

---
