### PR TITLE
Index layout file manually prints braces, quotes, keys, and values to build `index.json`, but fails to place commas 

### DIFF
--- a/themes/microcks/layouts/_default/index.json
+++ b/themes/microcks/layouts/_default/index.json
@@ -10,18 +10,18 @@
       {{- $.Scratch.Add "search_index" (slice $entry) -}}
     {{- end -}}
   {{- end -}}
+{{- end -}}
 
-  {{- if .Section -}}
-    {{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
-    {{- range $index, $page := $section -}}
-      {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
-        {{- $title := $page.Title -}}
-        {{- if $page.Params.bannertext -}}
-          {{- $title = $page.Params.bannertext -}}
-        {{- end -}}
-        {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
-        {{- $.Scratch.Add "search_index" (slice $entry) -}}
+{{- if $.Section -}}
+  {{- $section := (where site.Pages "Section" $.Section) | intersect (where site.Pages ".Title" "!=" $.Title) -}}
+  {{- range $index, $page := $section -}}
+    {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
+      {{- $title := $page.Title -}}
+      {{- if $page.Params.bannertext -}}
+        {{- $title = $page.Params.bannertext -}}
       {{- end -}}
+      {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
+      {{- $.Scratch.Add "search_index" (slice $entry) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/themes/microcks/layouts/_default/index.json
+++ b/themes/microcks/layouts/_default/index.json
@@ -1,36 +1,32 @@
-{{- $len := sub (len (.Pages.GroupBy "Section")) 1 -}}
-[{{- range $item, $el := .Pages.GroupBy "Section" -}}
-{{- range $i, $e := .Pages -}}
-{{- if and (not .Params.ignoreSearch) (ne $e.Type "json") -}}
-  {
-    "section": "",
-    "url": "{{ $e.Permalink }}",
-    "title": "{{ with $e.Params.bannertext }}{{htmlEscape .}}{{else}}{{htmlEscape $e.Title}}{{end}}",
-    "description": "{{ htmlEscape .Description}}",
-    "searchKeyword": "{{ htmlEscape .Params.searchKeyword}}",
-    "content": {{$e.Plain | jsonify}}
-  }{{- if eq $item $len -}}{{- else -}},{{- end -}}
-{{- end -}}
+{{- $.Scratch.Delete "search_index" -}}
+{{- range $item, $el := .Pages.GroupBy "Section" -}}
+  {{- range $i, $e := .Pages -}}
+    {{- if and (not $e.Params.ignoreSearch) (ne $e.Type "json") -}}
+      {{- $title := $e.Title -}}
+      {{- if $e.Params.bannertext -}}
+        {{- $title = $e.Params.bannertext -}}
+      {{- end -}}
+      {{- $entry := dict "section" "" "url" $e.Permalink "title" (htmlEscape $title) "description" (htmlEscape $e.Description) "searchKeyword" (htmlEscape $e.Params.searchKeyword) "content" $e.Plain -}}
+      {{- $.Scratch.Add "search_index" (slice $entry) -}}
+    {{- end -}}
+  {{- end -}}
 
-{{- if .Section -}}
-{{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
-{{- $sectionLen := len (where site.Pages "Section" .Section) -}}
-{{- $sectionLenTotal := sub $sectionLen 2 -}}
-
-{{- range $index, $page := $section -}}
-{{- if and (not .Params.ignoreSearch) (ne $page.Type "json") -}}
-  {
-    "section": "{{$page.Section | humanize}}",
-    "url": "{{ $page.Permalink }}",
-    "title": "{{ with $page.Params.bannertext }}{{htmlEscape .}}{{else}}{{htmlEscape $page.Title}}{{end}}",
-    "description": "{{ htmlEscape .Description}}",
-    "searchKeyword": "{{ htmlEscape .Params.searchKeyword}}",
-    "content": {{$page.Plain | jsonify}}
-  }{{- if eq $item $len -}}{{- if ne $index $sectionLenTotal -}},{{- end -}}{{- else -}},{{- end -}}
+  {{- if .Section -}}
+    {{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
+    {{- range $index, $page := $section -}}
+      {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
+        {{- $title := $page.Title -}}
+        {{- if $page.Params.bannertext -}}
+          {{- $title = $page.Params.bannertext -}}
+        {{- end -}}
+        {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
+        {{- $.Scratch.Add "search_index" (slice $entry) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
+{{- with $.Scratch.Get "search_index" -}}
+  {{- . | jsonify -}}
+{{- else -}}
+  []
 {{- end -}}
-
-{{- end -}}
-
-{{- end -}}
-{{- end -}}]

--- a/themes/microcks/layouts/documentation/index.json
+++ b/themes/microcks/layouts/documentation/index.json
@@ -10,18 +10,18 @@
       {{- $.Scratch.Add "search_index" (slice $entry) -}}
     {{- end -}}
   {{- end -}}
+{{- end -}}
 
-  {{- if .Section -}}
-    {{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
-    {{- range $index, $page := $section -}}
-      {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
-        {{- $title := $page.Title -}}
-        {{- if $page.Params.bannertext -}}
-          {{- $title = $page.Params.bannertext -}}
-        {{- end -}}
-        {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
-        {{- $.Scratch.Add "search_index" (slice $entry) -}}
+{{- if $.Section -}}
+  {{- $section := (where site.Pages "Section" $.Section) | intersect (where site.Pages ".Title" "!=" $.Title) -}}
+  {{- range $index, $page := $section -}}
+    {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
+      {{- $title := $page.Title -}}
+      {{- if $page.Params.bannertext -}}
+        {{- $title = $page.Params.bannertext -}}
       {{- end -}}
+      {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
+      {{- $.Scratch.Add "search_index" (slice $entry) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/themes/microcks/layouts/documentation/index.json
+++ b/themes/microcks/layouts/documentation/index.json
@@ -1,36 +1,32 @@
-{{- $len := sub (len (.Pages.GroupBy "Section")) 1 -}}
-[{{- range $item, $el := .Pages.GroupBy "Section" -}}
-{{- range $i, $e := .Pages -}}
-{{- if and (not .Params.ignoreSearch) (ne $e.Type "json") -}}
-  {
-    "section": "",
-    "url": "{{ $e.Permalink }}",
-    "title": "{{ with $e.Params.bannertext }}{{htmlEscape .}}{{else}}{{htmlEscape $e.Title}}{{end}}",
-    "description": "{{ htmlEscape .Description}}",
-    "searchKeyword": "{{ htmlEscape .Params.searchKeyword}}",
-    "content": {{$e.Plain | jsonify}}
-  },
-{{- end -}}
+{{- $.Scratch.Delete "search_index" -}}
+{{- range $item, $el := .Pages.GroupBy "Section" -}}
+  {{- range $i, $e := .Pages -}}
+    {{- if and (not $e.Params.ignoreSearch) (ne $e.Type "json") -}}
+      {{- $title := $e.Title -}}
+      {{- if $e.Params.bannertext -}}
+        {{- $title = $e.Params.bannertext -}}
+      {{- end -}}
+      {{- $entry := dict "section" "" "url" $e.Permalink "title" (htmlEscape $title) "description" (htmlEscape $e.Description) "searchKeyword" (htmlEscape $e.Params.searchKeyword) "content" $e.Plain -}}
+      {{- $.Scratch.Add "search_index" (slice $entry) -}}
+    {{- end -}}
+  {{- end -}}
 
-{{- if .Section -}}
-{{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
-{{- $sectionLen := len (where site.Pages "Section" .Section) -}}
-{{- $sectionLenTotal := sub $sectionLen 2 -}}
-
-{{- range $index, $page := $section -}}
-{{- if and (not .Params.ignoreSearch) (ne $page.Type "json") -}}
-  {
-    "section": "{{$page.Section | humanize}}",
-    "url": "{{ $page.Permalink }}",
-    "title": "{{ with $page.Params.bannertext }}{{htmlEscape .}}{{else}}{{htmlEscape $page.Title}}{{end}}",
-    "description": "{{ htmlEscape .Description}}",
-    "searchKeyword": "{{ htmlEscape .Params.searchKeyword}}",
-    "content": {{$page.Plain | jsonify}}
-  }{{- if eq $item $len -}}{{- if ne $index $sectionLenTotal -}},{{- end -}}{{- else -}},{{- end -}}
+  {{- if .Section -}}
+    {{- $section := (where site.Pages "Section" .Section) | intersect (where site.Pages ".Title" "!=" .Title) -}}
+    {{- range $index, $page := $section -}}
+      {{- if and (not $page.Params.ignoreSearch) (ne $page.Type "json") -}}
+        {{- $title := $page.Title -}}
+        {{- if $page.Params.bannertext -}}
+          {{- $title = $page.Params.bannertext -}}
+        {{- end -}}
+        {{- $entry := dict "section" ($page.Section | humanize) "url" $page.Permalink "title" (htmlEscape $title) "description" (htmlEscape $page.Description) "searchKeyword" (htmlEscape $page.Params.searchKeyword) "content" $page.Plain -}}
+        {{- $.Scratch.Add "search_index" (slice $entry) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
+{{- with $.Scratch.Get "search_index" -}}
+  {{- . | jsonify -}}
+{{- else -}}
+  []
 {{- end -}}
-
-{{- end -}}
-
-{{- end -}}
-{{- end -}}]


### PR DESCRIPTION
Closes #556 
### Describe the bug

### Description
The search index layout file manually prints braces, quotes, keys, and values to build `index.json`, but fails to place commas between items in the page range loop, or prints trailing commas when pages are excluded.

* **File Link:** [themes/microcks/layouts/_default/index.json](file:///c:/Users/Hp/microcks.io/themes/microcks/layouts/_default/index.json)
* **Code Snippet:**
  ```json
  }{{- if eq $item $len -}}{{- else -}},{{- end -}}
  ```

### Why It Breaks
Without proper comma delimiters between items in the inner loop, the result is malformed JSON. Furthermore, if a page is excluded (e.g., `ignoreSearch: true`), the hardcoded comma rendering logic results in trailing commas (e.g. `[ { ... }, ]`) or consecutive commas (e.g., `,,`). This causes `JSON.parse()` to throw a syntax error in the browser and completely breaks the search capability.

### How to Reproduce
1. Configure any documentation page with `ignoreSearch = true` in frontmatter.
2. Build the Hugo site: `hugo`.
3. Open the output file `public/index.json` and validate it using a JSON validator (like `JSON.parse()` in Node.js).
4. Observe the parsing failure due to syntax error.




