### PR TITLE
The copyright text variable configured in parameters uses a hardcoded trademark string.

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -37,7 +37,7 @@ table_of_content = true
 
 # copyright
 theme_copyright = false
-copyright = "The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [**Trademark Usage**.](https://www.linuxfoundation.org/legal/trademark-usage) <br> **Microcks** is a [**Cloud Native Computing Incubating**](https://landscape.cncf.io/?selected=microcks&item=app-definition-and-development--application-definition-image-build--microcks) project 🚀"
+copyright = "Copyright &copy; {year} The Linux Foundation® (TLF) has registered trademarks and uses trademarks. For a list of TLF trademarks, see [**Trademark Usage**.](https://www.linuxfoundation.org/legal/trademark-usage) <br> **Microcks** is a [**Cloud Native Computing Incubating**](https://landscape.cncf.io/?selected=microcks&item=app-definition-and-development--application-definition-image-build--microcks) project 🚀"
 
 # Preloader
 [preloader]

--- a/themes/microcks/layouts/partials/footer.html
+++ b/themes/microcks/layouts/partials/footer.html
@@ -59,7 +59,7 @@
     </div>
   </div>
   <div class="border-top border-default text-center py-4 mt-4" style="width: 100%;">
-    <small class="content">{{ site.Params.Copyright | markdownify }}</small>
+    <small class="content">{{ replace site.Params.Copyright "{year}" (now.Format "2006") | markdownify }}</small>
   </div>
   <!-- Add scarf.sh gentle pixel tracker -->
   <img style="max-width: 0px; max-height: 0px;" referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=19c4c77c-b3f5-4936-a328-7248d6f29cae" />


### PR DESCRIPTION
Closes #559 
### Description
The copyright text variable configured in parameters uses a hardcoded trademark string.

* **Location:** [config/_default/params.toml](file:///c:/Users/Hp/microcks.io/config/_default/params.toml#L40)
* **Rationale:** The copyright text is static, meaning it does not update to show the current year dynamically. This requires manual updates annually.
* **How to Verify:** View the copyright information printed in the footer.

### Verification Flow
```mermaid
graph TD
    A[Start: Inspect footer copyright element] --> B[Analyze copyright year parameters]
    B --> C{Is year hardcoded in params?}
    C -- Yes --> D[Issue Confirmed: Inflexible copyright configuration]
    C -- No --> E[Dynamic year generation]
```